### PR TITLE
Install StimulusJS explicitly in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This template requires the following installed on your system:
 
 ### Create a new app
 
-    rails new myapp -T -d=postgresql --webpack=stimulus -m https://raw.githubusercontent.com/ryan-hunter-pc/jumpstart/master/template.rb
+    rails new myapp -T -d=postgresql --webpack -m https://raw.githubusercontent.com/ryan-hunter-pc/jumpstart/master/template.rb
     cd myapp
     
 ### Run the setup script to setup a local development environment


### PR DESCRIPTION
BEFORE
The template's StimulusJS installation relied on including `--webpack=stimulus` in the `rails new` call.

SOLUTION
Promote the StimulusJS installation to a first-class step in the template, which also allows properly encapsulating the StimulusJS-related config fixes we were already doing in an explicit step. It depends on `--webpack` in the `rails new` call still, but that is much more clear and resilient than specifically requiring `--webpack=stimulus`.
